### PR TITLE
[whizz] Fix build error: multiple definition of 'yylloc'.

### DIFF
--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+//YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
Fix build error: multiple definition of `yylloc'
Mentioned in [Linux Kernel Mailing List](https://lkml.org/lkml/2020/4/1/1206)