### PR TITLE
[Breaking build] Fix a compilation error picked up by Clang 11.

### DIFF
--- a/drivers/oneplus/coretech/memplus/core/memplus_core.c
+++ b/drivers/oneplus/coretech/memplus/core/memplus_core.c
@@ -136,7 +136,7 @@ static inline bool current_is_gcd(void)
 	return current == gc_tsk;
 }
 
-bool ctech_current_is_swapind() {
+bool ctech_current_is_swapind(void) {
 	return current == swapind_tsk;
 }
 


### PR DESCRIPTION
## Description
I will try to explain why we need to do this pull request. Firstly, why did this only break build in later Clang? I am really not sure. Maybe changes to compiler behavior, although I cannot pinpoint what change it is.

Why is this needed?
Well, it shouldn't, but a combination of flags made this a build breaking issue. They enabled -Wstrict-prototypes, which means all functions must declare their arguments explicitly, if it does not take an argument you need to specify by declaring it as foo(void). They then went to set strict prototypes as an error instead of a warning, so compilation will break because of this error.

**TLDR**: If the kernel source has a function declared without explicity stating its arguments, even if it would be void, it will fail.

FYI, for anyone still reading, the function literally just above it, which is very similar except for small changes gets it right. Oneplus kernel codebase is great isn't it?

## Type of change
- [ ] Optimization (change optimizes kernel and not expected to change behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Others: Fix build in Clang 11

# Checklist
- [ ] I have not cleaned up my code. Forgive the minor errors
- [x] I have performed a self-review of my own code. Feel free to destroy my PR
- [ ] I have commented my code, particularly in hard-to-understand areas
